### PR TITLE
Tag devel: erledigte Use Cases

### DIFF
--- a/src/business/error.rs
+++ b/src/business/error.rs
@@ -16,6 +16,9 @@ quick_error!{
         Url{
             description("Invalid URL")
         }
+        Tag{
+           description("Invalid Tag")
+        }
     }
 }
 

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -390,6 +390,60 @@ pub mod tests {
     /////////////////////////
 
     #[test]
+    // ENVIRONMENT: tags, entries, some links from tags to entries
+    // INPUT: vec of one tag (undefined)
+    // OUTPUT: vec of associated entries
+    // ASSERT: output should be empty
+    fn search_by_undefined_tag()
+    {
+        // SETUP
+
+        let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+        let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+        let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+        let x = NewEntry {
+            title       : "foo".into(),
+            description : "bar".into(),
+            lat         : 0.0,
+            lng         : 0.0,
+            street      : None,
+            zip         : None,
+            city        : None,
+            country     : None,
+            email       : None,
+            telephone   : None,
+            homepage    : None,
+            categories  : vec![],
+            tags        : vec![],
+            license     : "CC0-1.0".into()
+        };
+
+        let entry_id = create_new_entry(&mut re, x).unwrap();
+
+        let tag_name  = "baz";
+
+        let tag_id = create_new_tag(&mut rt, NewTag{name:tag_name.to_string()}).unwrap();
+
+        rs.create(&SentenceTriple {
+            subject   : entry_id.clone(),
+            predicate : Predicate::IsTaggedAs,
+            object    : tag_id.clone()
+        });
+
+        // RUN
+        let result = search_by_tags(&re, &mut rt, &rs, &vec!["mock".into()]);
+
+        // CHECK
+        let entry_vec = result.unwrap();
+        assert_eq!(entry_vec.len(), 0);
+    }
+
+    #[test]
+    // ENVIRONMENT: tags, entries, some links from tags to entries
+    // INPUT: vec of one tag (existing)
+    // OUTPUT: vec of associated entries
+    // ASSERT: only the fitting entries are given back
     fn search_by_defined_tag()
     {
         // SETUP
@@ -523,28 +577,6 @@ pub mod tests {
     // ASSERT: vec of entities is empty
     fn search_on_empty_db()
     {
-    }
-
-    #[ignore]
-    #[test]
-    // ENVIRONMENT: tags, entries, some links from tags to entries
-    // INPUT: vec of one tag (existing)
-    // OUTPUT: vec of associated entries
-    // ASSERT: only the fitting entries are given back
-    fn search_by_one_tag()
-    {
-        unimplemented!();
-    }
-
-    #[ignore]
-    #[test]
-    // ENVIRONMENT: tags, entries, some links from tags to entries
-    // INPUT: vec of one tag (undefined)
-    // OUTPUT: vec of associated entries
-    // ASSERT: output should be empty
-    fn search_by_undefined_tag()
-    {
-        unimplemented!();
     }
 
     ////////////////////////////////

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -436,6 +436,63 @@ pub mod tests {
         assert_eq!(entry_vec[0].id, entry_id);
     }
 
+    #[test]
+    fn search_by_two_defined_tags()
+    {
+        // SETUP
+
+        let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+        let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+        let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+        let x = NewEntry {
+            title       : "foo".into(),
+            description : "bar".into(),
+            lat         : 0.0,
+            lng         : 0.0,
+            street      : None,
+            zip         : None,
+            city        : None,
+            country     : None,
+            email       : None,
+            telephone   : None,
+            homepage    : None,
+            categories  : vec![],
+            tags        : vec![],
+            license     : "CC0-1.0".into()
+        };
+
+        let entry_id = create_new_entry(&mut re, x).unwrap();
+
+        let tag_name1  = "bazooka";
+        let tag_id1 = create_new_tag(&mut rt, NewTag{name:tag_name1.to_string()}).unwrap();
+
+        let tag_name2 = "bacillus";
+        let tag_id2 =  create_new_tag(&mut rt, NewTag{name:tag_name2.to_string()}).unwrap();
+
+        let tag_vec = vec![tag_name1.to_string(), tag_name2.to_string()];
+
+        rs.create(&SentenceTriple {
+            subject   : entry_id.clone(),
+            predicate : Predicate::IsTaggedAs,
+            object    : tag_id1.clone()
+        });
+        rs.create(&SentenceTriple {
+            subject   : entry_id.clone(),
+            predicate : Predicate::IsTaggedAs,
+            object    : tag_id2.clone()
+        });
+
+
+        // RUN
+        let result = search_by_tags(&re, &mut rt, &rs, &tag_vec);
+
+        // CHECK
+        let entry_vec = result.unwrap();
+        assert_eq!(entry_vec.len(), 1); // assume no doublettes
+        assert_eq!(entry_vec[0].id, entry_id);
+    }
+
     #[ignore]
     #[test]
     // ENVIRONMENT: tags, entries, some links from tags to entries

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -421,6 +421,65 @@ pub mod tests {
         unimplemented!();
     }
 
+    ////////////////////////////////
+    // Tag Addition Tests
+    ////////////////////////////////
+
+    #[test]
+    fn add_empty_tag_to_entry()
+    {
+       // SETUP
+       let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+       let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+       let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+       // RUN
+       // CHECK
+    }
+
+    #[test]
+    fn add_valid_tag_to_entry()
+    {
+       // SETUP
+       let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+       let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+       let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+       // RUN
+       // CHECK
+    }
+
+    #[test]
+    fn add_uppercase_tag_to_entry()
+    {
+       // SETUP
+       let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+       let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+       let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+       // RUN
+       // CHECK
+    }
+
+    #[test]
+    fn add_untrimmed_tag_to_entry()
+    {
+       // SETUP
+       let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+       let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+       let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+       // RUN
+       // CHECK
+    }
+
+    #[test]
+    fn add_tag_with_invalid_characters_to_entry()
+    {
+    }
+
+
+
     type RepoResult<T> = result::Result<T, RepoError>;
 
     pub struct MockRepo<T> {

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -387,6 +387,20 @@ pub mod tests {
 
     #[ignore]
     #[test]
+    // ENVIRONMENT:
+    // * no tags, no entries, no links
+    // * alternate: tags, and entries, but no links
+    // * alternate: tags, but no entries and links
+    // * alternate: entries, but no tags and links
+    // INPUT: a tag vec
+    // OUTPUT: vec of entities
+    // ASSERT: vec of entities is empty
+    fn search_on_empty_db()
+    {
+    }
+
+    #[ignore]
+    #[test]
     // ENVIRONMENT: tags, entries, some links from tags to entries
     // INPUT: vec of one tag (existing)
     // OUTPUT: vec of associated entries

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -363,13 +363,25 @@ pub mod tests {
 
     use super::*;
 
+    /////////////////////////
+    // Entry Search Tests
+    /////////////////////////
+
     #[ignore]
     #[test]
     // ENVIRONMENT: tags, entries, some links from tags to entries
     // INPUT: empty vec of tags
-    // OUTPUT: empty vec of entities
+    // OUTPUT: vec of entities
+    // ASSERT: vec of entities is empty
     fn empty_search_by_tags()
     {
+       // SETUP
+       let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+       let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+       let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+       // RUN
+       // CHECK
         unimplemented!();
     }
 

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -783,6 +783,56 @@ pub mod tests {
         assert!(result.is_err());
     }
 
+    ////////////////////////////////
+    // Tests on Get Entry
+    ////////////////////////////////
+
+    #[test]
+    fn get_entry_with_invalid_id()
+    {
+        // SETUP
+
+        let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+        let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+        let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+        let x = NewEntry {
+            title       : "foo".into(),
+            description : "bar".into(),
+            lat         : 0.0,
+            lng         : 0.0,
+            street      : None,
+            zip         : None,
+            city        : None,
+            country     : None,
+            email       : None,
+            telephone   : None,
+            homepage    : None,
+            categories  : vec![],
+            tags        : vec![],
+            license     : "CC0-1.0".into()
+        };
+
+        let entry_id = create_new_entry(&mut re, x).unwrap();
+
+        let tag_name  = "baz";
+
+        let tag_id = create_new_tag(&mut rt, NewTag{name:tag_name.to_string()}).unwrap();
+
+        rs.create(&SentenceTriple {
+            subject   : entry_id.clone(),
+            predicate : Predicate::IsTaggedAs,
+            object    : tag_id.clone()
+        });
+
+        // RUN
+
+        let result = request_entry(&re, &rt, &rs, &"0");
+
+        // CHECK
+
+        assert!(result.is_err());
+    }
 
 
     type RepoResult<T> = result::Result<T, RepoError>;

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -99,6 +99,7 @@ pub fn add_tag_to_entry<RE : Repo<Entry>, RT : Repo<Tag>, RS : Repo<SentenceTrip
 
     let tag_id_res = find_or_create_tag_id_by_name(rt, tag);
     let tag_ids_of_entry : Vec<String> = get_tags_for_entry_id(rt, rs, entry_id)?;
+
     match tag_id_res {
         Ok(tag_id) => {
             match tag_ids_of_entry.iter().find(|id| **id == tag_id) {
@@ -494,8 +495,36 @@ pub mod tests {
         let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
         let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
 
+        let x = NewEntry {
+            title       : "foo".into(),
+            description : "bar".into(),
+            lat         : 0.0,
+            lng         : 0.0,
+            street      : None,
+            zip         : None,
+            city        : None,
+            country     : None,
+            email       : None,
+            telephone   : None,
+            homepage    : None,
+            categories  : vec![],
+            tags        : vec![],
+            license     : "CC0-1.0".into()
+        };
+
+        let entry_id = create_new_entry(&mut re, x).unwrap();
+
+        let tag_name  = "baz";
+
         // RUN
+
+        let result = add_tag_to_entry(&re, &mut rt, &mut rs, tag_name, &entry_id);
+
         // CHECK
+
+        assert!(result.is_ok());
+        assert_eq!(rt.objects.len(), 1);
+        assert_eq!(rs.objects.len(), 1);
     }
 
     #[test]

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -71,6 +71,7 @@ pub fn get_tags_for_entry_id<RT : Repo<Tag>, RS : Repo<SentenceTriple>>(rt : &RT
 pub fn get_tag_names_from_ids<RT : Repo<Tag>>(rt : RT, id : &str) -> Result<Vec<String>> {
     Ok(rt.all()?
         .into_iter()
+        .filter(|t| t.id == id)
         .map(|t| t.name)
         .collect())
 }

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -87,6 +87,14 @@ fn add_entry_with_tags<RE : Repo<Entry>, RT : Repo<Tag>, RS : Repo<SentenceTripl
 ////////////////
 
 ////////////////
+// USE CASE: user removes a tag relation from an entry
+
+// TODO: get clear, how to remove a relation from the DB...
+
+// USE CASE: user removes a tag relation from an entry
+////////////////
+
+////////////////
 // USE CASE: user adds a tag to an entry
 //
 // What should happen:

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -389,6 +389,53 @@ pub mod tests {
     // Entry Search Tests
     /////////////////////////
 
+    #[test]
+    fn search_by_defined_tag()
+    {
+        // SETUP
+
+        let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+        let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+        let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+        let x = NewEntry {
+            title       : "foo".into(),
+            description : "bar".into(),
+            lat         : 0.0,
+            lng         : 0.0,
+            street      : None,
+            zip         : None,
+            city        : None,
+            country     : None,
+            email       : None,
+            telephone   : None,
+            homepage    : None,
+            categories  : vec![],
+            tags        : vec![],
+            license     : "CC0-1.0".into()
+        };
+
+        let entry_id = create_new_entry(&mut re, x).unwrap();
+
+        let tag_name  = "baz";
+
+        let tag_id = create_new_tag(&mut rt, NewTag{name:tag_name.to_string()}).unwrap();
+
+        rs.create(&SentenceTriple {
+            subject   : entry_id.clone(),
+            predicate : Predicate::IsTaggedAs,
+            object    : tag_id.clone()
+        });
+
+        // RUN
+        let result = search_by_tags(&re, &mut rt, &rs, &vec![tag_name.to_string()]);
+
+        // CHECK
+        let entry_vec = result.unwrap();
+        assert_eq!(entry_vec.len(), 1);
+        assert_eq!(entry_vec[0].id, entry_id);
+    }
+
     #[ignore]
     #[test]
     // ENVIRONMENT: tags, entries, some links from tags to entries

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -84,19 +84,6 @@ pub fn get_tags_for_entry_id<RT : Repo<Tag>, RS : Repo<SentenceTriple>>(rt : &RT
 // ** save conection to repo
 
 pub fn add_tag_to_entry<RE : Repo<Entry>, RT : Repo<Tag>, RS : Repo<SentenceTriple>>(re : &RE, rt : &mut RT, rs : &mut RS, tag : &str, entry_id : &str) -> Result<(String)> {
-    let t_string = tag.to_ascii_lowercase();
-    let tag = t_string.trim();
-
-    if tag == ""
-    {
-        return Err(Error::Parameter(ParameterError::Tag));
-    }
-
-    if tag.chars().find(|c| !c.is_alphabetic()).is_some()
-    {
-        return Err(Error::Parameter(ParameterError::Tag));
-    }
-
     let tag_id_res = find_or_create_tag_id_by_name(rt, tag);
     let tag_ids_of_entry : Vec<String> = get_tags_for_entry_id(rt, rs, entry_id)?;
 
@@ -119,6 +106,19 @@ pub fn add_tag_to_entry<RE : Repo<Entry>, RT : Repo<Tag>, RS : Repo<SentenceTrip
 }
 
 pub fn find_or_create_tag_id_by_name<RT : Repo<Tag>>(rt : &mut RT, tag : &str) -> Result<String> {
+    let t_string = tag.to_ascii_lowercase();
+    let tag = t_string.trim();
+
+    if tag == ""
+    {
+        return Err(Error::Parameter(ParameterError::Tag));
+    }
+
+    if tag.chars().find(|c| !c.is_alphabetic()).is_some()
+    {
+        return Err(Error::Parameter(ParameterError::Tag));
+    }
+
     match rt.all()?
         .into_iter()
         .find(|t| t.name == tag)

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -68,15 +68,6 @@ pub fn get_tags_for_entry_id<RT : Repo<Tag>, RS : Repo<SentenceTriple>>(rt : &RT
         .collect())
 }
 
-// Now, as you have the tag IDs, you can get the names.
-pub fn get_tag_names_from_ids<RT : Repo<Tag>>(rt : RT, id : &str) -> Result<Vec<String>> {
-    Ok(rt.all()?
-        .into_iter()
-        .filter(|t| t.id == id)
-        .map(|t| t.name)
-        .collect())
-}
-
 //
 // USE CASE: user requests an entry (head entry, no date restriction)
 ////////////////

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -73,6 +73,20 @@ pub fn get_tags_for_entry_id<RT : Repo<Tag>, RS : Repo<SentenceTriple>>(rt : &RT
 ////////////////
 
 ////////////////
+// USE CASE: user creates an entry with tags
+
+fn add_entry_with_tags<RE : Repo<Entry>, RT : Repo<Tag>, RS : Repo<SentenceTriple>>(re : &mut RE, rt : &mut RT, rs : &mut RS, tags : &Vec<String>, entry : NewEntry) -> Result<(String)> {
+    let entry_id = create_new_entry(re, entry)?;
+    for tag in tags.iter() {
+        add_tag_to_entry(re, rt, rs, tag, &entry_id)?;
+    }
+    Ok((entry_id))
+}
+
+// USE CASE: user creates an entry with tags
+////////////////
+
+////////////////
 // USE CASE: user adds a tag to an entry
 //
 // What should happen:

--- a/src/business/usecase.rs
+++ b/src/business/usecase.rs
@@ -834,6 +834,55 @@ pub mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn get_entry_with_valid_id()
+    {
+        // SETUP
+
+        let mut rt : MockRepo<Tag> = MockRepo { objects : vec![] };
+        let mut re : MockRepo<Entry> = MockRepo { objects : vec![] };
+        let mut rs : MockRepo<SentenceTriple> = MockRepo { objects : vec![] };
+
+        let x = NewEntry {
+            title       : "foo".into(),
+            description : "bar".into(),
+            lat         : 0.0,
+            lng         : 0.0,
+            street      : None,
+            zip         : None,
+            city        : None,
+            country     : None,
+            email       : None,
+            telephone   : None,
+            homepage    : None,
+            categories  : vec![],
+            tags        : vec![],
+            license     : "CC0-1.0".into()
+        };
+
+        let entry_id = create_new_entry(&mut re, x).unwrap();
+
+        let tag_name  = "baz";
+
+        let tag_id = create_new_tag(&mut rt, NewTag{name:tag_name.to_string()}).unwrap();
+
+        rs.create(&SentenceTriple {
+            subject   : entry_id.clone(),
+            predicate : Predicate::IsTaggedAs,
+            object    : tag_id.clone()
+        });
+
+        // RUN
+
+        let result = request_entry(&re, &rt, &rs, &entry_id);
+
+        // CHECK
+
+        assert!(result.is_ok());
+        let entry = result.unwrap();
+        assert_eq!(entry.tags.len(), 1);
+        assert_eq!(entry.tags[0], tag_id);
+    }
 
     type RepoResult<T> = result::Result<T, RepoError>;
 

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -27,7 +27,7 @@ pub struct Category {
     pub name      : String
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Tag {
     pub id        : String,
     pub created   : u64,

--- a/src/infrastructure/db/neo4j.rs
+++ b/src/infrastructure/db/neo4j.rs
@@ -259,3 +259,85 @@ impl Repo<Category> for GraphClient {
         Ok(())
     }
 }
+
+impl Repo<Tag> for GraphClient {
+
+    fn get(&self, id: &str) -> Result<Tag> {
+        let result = self.exec(cypher_stmt!(
+        "MATCH (e:Tag)<--(s:CategoryState) WHERE t.id = {id}
+         WITH max(s.created) as created
+         MATCH (x:Tag)<--(s:CategoryState)
+         WHERE t.id = {id} AND s.created = created
+         WITH t, s
+         RETURN {
+           id      : t.id,
+           version : s.version,
+           created : s.created,
+           name    : s.name
+         } AS t", {"id" => &id})?)?;
+        let r = result.rows().next().ok_or(RepoError::NotFound)?;
+        let t = r.get::<Tag>("t")?;
+        Ok(t)
+    }
+
+    fn all(&self) -> Result<Vec<Tag>> {
+        let result = self.exec(
+        "MATCH (t:Tag)<--(s:CategoryState)
+         RETURN {
+           id      : t.id,
+           version : s.version,
+           created : s.created,
+           name    : s.name
+         } AS t")?;
+        Ok(result
+            .rows()
+            .filter_map(|r| r.get::<Tag>("t").ok())
+            .collect::<Vec<Tag>>())
+    }
+
+    fn create(&mut self, t: &Tag) -> Result<()> {
+        self.exec(cypher_stmt!(
+        "CREATE (t:Tag {id:{id}})
+         MERGE t<-[:BELONGS_TO]-(s:CategoryState {
+           created : timestamp(),
+           version : 1,
+           name    : {name}
+         })
+         RETURN {
+           id      : t.id,
+           version : s.version,
+           created : s.created,
+           name    : s.name
+         } AS t", {
+           "id"   => &t.id,
+           "name" => &t.name
+        })?)?;
+        Ok(())
+    }
+
+    fn update(&mut self, t: &Tag) -> Result<()> {
+        debug!("update tag: {}", t.id);
+        self.exec(cypher_stmt!(
+        "MATCH (t:Category)<--(s:CategoryState) WHERE t.id = {id}
+         WITH max(s.version) as v
+         MATCH (t:Category)<--(old:CategoryState)
+         WHERE t.id = {id} AND old.version = v AND old.version + 1 = {version}
+         WITH t,e
+         MERGE t<-[:BELONGS_TO]-(s:CategoryState {
+           created : timestamp(),
+           version : {version},
+           name    : {name}
+         })
+         RETURN {
+           id      : t.id,
+           version : s.version,
+           created : s.created,
+           name    : s.name
+         } AS t", {
+           "id"      => &t.id,
+           "version" => &t.version,
+           "name"    => &t.name
+         })?)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Hallo Markus,

folgende Use Cases sind bereits abgedeckt:
1. create_tag: usecase.rs: /121) find_or_create_tag_by_name
  noch nicht gesondert getestet, allerdings hat die aufrufende Funktion (86) add_tag_to_entry so weit
  alle Tests bestanden. Damit find_or_create_tag_by_name die gleiche Sicherheit bietet, müssen
  die Sicherheitsabfragen aus add_tag_to_entry hierhin umgezogen werden.
2. get_tags -> Vec<Tag>: Habe ich dich richtig verstanden: soll alle Tags der DB zurückliefern?
  Abgedeckt durch Repo<Tag>.all() -- oder?

Noch offen:
3. get_entry(id) -> Entry { ... tags: Vec<String> ... } -- implementiert, aber nicht getestet als
  (24) request_entry
4. neuer Entry, ohne Tag -- nicht abgedeckt durch Repo<Entry>.create?
5. neuer Eintrag, mit Tag-Liste
6. Update Entry, mit veränderter Tag-Liste
  5. und 6. können zurückgreifen auf (86) add_tag_to_entry -- fehlt noch ein Remove der Tag-Relation.
7. get_all_entries: ohne Tags realisiert als Repo<Entry>.all -- die Tag-IDs können über
  (24) request_entry gewonnen werden, bzw. (53) get_tags_for_entry_id (beide nicht getestet).
8. (157) search_by_tags: noch testen.
